### PR TITLE
absolute links with file base url

### DIFF
--- a/lib/proto/file.js
+++ b/lib/proto/file.js
@@ -8,9 +8,15 @@ const url = require('url');
 
 module.exports = {
     check: function (link, baseUrl, callback) {
-        let filepath = url.parse(link, false, true).path || '';
-        if (!path.isAbsolute(filepath)) {
-            const basepath = url.parse(baseUrl, false, true).path || process.cwd();
+        const basepath = url.parse(baseUrl || process.cwd(), false, true).path;
+        const linkUrl = url.parse(link, false, true);
+        let filepath = linkUrl.path || '';
+
+        if (path.isAbsolute(filepath) && !linkUrl.protocol) {
+            // File links are not truly absolute. On a webserver `/` points to a root.
+            // So protocolless links should point relative to the base path.
+            filepath = path.join(basepath, filepath);
+	} else if (filepath) {
             filepath = path.resolve(basepath, filepath);
         }
 

--- a/test/link-check.test.js
+++ b/test/link-check.test.js
@@ -168,6 +168,16 @@ describe('link-check', function () {
         });
     });
 
+    it('should resolve from the base on absolute protocol relative links', function(done) {
+        linkCheck('/fixtures/file.md', { baseUrl: 'file://' + process.cwd() + '/test/' }, function(err, result) {
+            expect(err).to.be(null);
+
+            expect(result.err).to.be(null);
+            expect(result.status).to.be('alive');
+            done();
+        });
+    });
+
     it('should ignore file protocol on fragment links', function(done) {
         linkCheck('#foobar', { baseUrl: 'file://' }, function(err, result) {
             expect(err).to.be(null);


### PR DESCRIPTION
This is not in a state to be merged yet.

I do this to replicate GitHub rendering and verify our documentation. It includes some links that are absolute and work just fine on GitHub.

Maybe this is not 100% complete as the `markdown-link-check` sets the base to the document directory and not the project directory.

I guess there might be either second configuration needed or passing around the path of the document being tested. Because on github there are two "bases". One for relative urls `./foo/bar` from the file and one absolute `/foo/bar` from the project.
