### PR TITLE
fix for interoperatibility with atom and electron based applications

### DIFF
--- a/lib/proto/file.js
+++ b/lib/proto/file.js
@@ -3,14 +3,14 @@
 const fs = require('fs');
 const LinkCheckResult = require('../LinkCheckResult');
 const path = require('path');
-const process = require('process');
+const processModule = require('process');
 const url = require('url');
 
 module.exports = {
     check: function (link, baseUrl, callback) {
         let filepath = url.parse(link, false, true).path || '';
         if (!path.isAbsolute(filepath)) {
-            const basepath = url.parse(baseUrl, false, true).path || process.cwd();
+            const basepath = url.parse(baseUrl, false, true).path || processModule.cwd();
             filepath = path.resolve(basepath, filepath);
         }
 


### PR DESCRIPTION
Minor fix to make it work with atom editor (and other electron based applications) 

TEST RESULTS: 
```
  link-check
    ✓ should find that a valid link is alive
    ✓ should find that a valid relative link is alive
    ✓ should find that an invalid link is dead
    ✓ should find that an invalid relative link is dead
    ✓ should report no DNS entry as a dead link (495ms)
    ✓ should try GET if HEAD fails
    ✓ should handle redirects
    ✓ should handle valid mailto
    ✓ should handle invalid mailto
    ✓ should handle file protocol
    ✓ should handle file protocol and invalid files
    ✓ should ignore file protocol on absolute links
    ✓ should ignore file protocol on fragment links
    ✓ should callback with an error on unsupported protocol
    ✓ should handle redirect loops (55ms)


  15 passing (700ms)
```

Fixes errors such as:
```
Identifier 'process' has already been declared

SyntaxError: Identifier 'process' has already been declared
    at Module._compile (/usr/share/atom/resources/app/src/native-compile-cache.js:75:40)
    at Object.value [as .js] (/usr/share/atom/resources/app/src/compile-cache.js:225:23)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.require (module.js:483:17)
    at require (/usr/share/atom/resources/app/src/native-compile-cache.js:47:27)
    at /packages/atom-test-linkcheck/node_modules/link-check/index.js:5:11)
    at Module._compile (/usr/share/atom/resources/app/src/native-compile-cache.js:87:30)
    at Object.value [as .js] (/usr/share/atom/resources/app/src/compile-cache.js:225:23)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.require (module.js:483:17)
    at require (/usr/share/atom/resources/app/src/native-compile-cache.js:47:27)
    at /packages/atom-test-linkcheck/lib/test-linkcheck.js:15:17)
    at Module._compile (/usr/share/atom/resources/app/src/native-compile-cache.js:87:30)
    at Object.value [as .js] (/usr/share/atom/resources/app/src/compile-cache.js:225:23)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.require (module.js:483:17)
    at require (/usr/share/atom/resources/app/src/native-compile-cache.js:47:27)
    at Package.module.exports.Package.requireMainModule (/usr/share/atom/resources/app/src/package.js:885:29)
    at Package.module.exports.Package.activateNow (/usr/share/atom/resources/app/src/package.js:240:16)
    at /usr/share/atom/resources/app/src/package.js:223:32
    at Package.module.exports.Package.measure (/usr/share/atom/resources/app/src/package.js:97:15)
    at /usr/share/atom/resources/app/src/package.js:216:26
    at Package.module.exports.Package.activate (/usr/share/atom/resources/app/src/package.js:213:34)
    at PackageManager.module.exports.PackageManager.activatePackage (/usr/share/atom/resources/app/src/package-manager.js:640:34)
```