### PR TITLE
Fix: Crash when first link in file is ignored/replaced

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function linkCheck(link, opts, callback) {
     }
 
     opts.timeout = opts.timeout || '10s';
-    opts.aliveStatusCodes = opts.aliveStatusCodes || [ 200 ];
+    
 
     const protocol = (url.parse(link, false, true).protocol || url.parse(opts.baseUrl, false, true).protocol || 'unknown:').replace(/:$/, '');
     if (!protocols.hasOwnProperty(protocol)) {

--- a/lib/LinkCheckResult.js
+++ b/lib/LinkCheckResult.js
@@ -2,6 +2,8 @@
 
 class LinkCheckResult {
     constructor(opts, link, statusCode, err) {
+        opts.aliveStatusCodes = opts.aliveStatusCodes || [ 200 ];
+        
         this.link = link;
         this.statusCode = statusCode || 0;
         this.err = err || null;


### PR DESCRIPTION
Set default of `opts.aliveStatusCodes` at the only place where it is consumed so that `LinkCheckResult` gets reusable.

Addresses: https://github.com/tcort/markdown-link-check/issues/50