### PR TITLE
Add support for retry count on 429 response codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Parameters:
    * `aliveStatusCodes` an array of numeric HTTP Response codes which indicate that the link is alive. Entries in this array may also be regular expressions. Example: `[ 200, /^[45][0-9]{2}$/ ]`.  Default `[ 200 ]`.
    * `headers` a string based attribute value object to send custom HTTP headers. Example: `{ 'Authorization' : 'Basic Zm9vOmJhcg==' }`.
    * `retryOn429` a boolean indicating whether to retry on a 429 (Too Many Requests) response. When true, a retry will only be attempted when the response includes a `retry-after` header that indicates how long to wait before retrying.
+   * `retryCount` the number of retries to be made on a 429 response. Default `2`.
  * `callback` function which accepts `(err, result)`.
    * `err` an Error object when the operation cannot be completed, otherwise `null`.
    * `result` an object with the following properties:

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = function linkCheck(link, opts, callback) {
 
     opts.timeout = opts.timeout || '10s';
     opts.retryOn429 = opts.retryOn429 || false;
+    opts.retryCount = opts.retryCount || 2;
 
     const protocol = (url.parse(link, false, true).protocol || url.parse(opts.baseUrl, false, true).protocol || 'unknown:').replace(/:$/, '');
     if (!protocols.hasOwnProperty(protocol)) {

--- a/lib/proto/http.js
+++ b/lib/proto/http.js
@@ -23,7 +23,7 @@ module.exports = {
             strictSSL: false,
             timeout: ms(opts.timeout),
         };
-        
+
         if (opts.baseUrl && isRelativeUrl(link)) {
             options.baseUrl = opts.baseUrl;
         }
@@ -41,7 +41,7 @@ module.exports = {
             // if HEAD fails (405 Method Not Allowed, etc), try GET
             request.get(options, function (err, res) {
                 // If enabled in opts, the response was a 429 (Too Many Requests) and there is a retry-after provided, wait and then retry
-                if (opts.retryOn429 && res && res.statusCode === 429 && res.headers.hasOwnProperty('retry-after') && attempts < 2) {
+                if (opts.retryOn429 && res && res.statusCode === 429 && res.headers.hasOwnProperty('retry-after') && attempts < opts.retryCount) {
                     const retryStr = res.headers['retry-after'];
                     // Sites may respond with a retry-after such as '1m30s', so we need to split this into distinct
                     // time units (separate '1m' and '30s') for zeit/ms to parse them


### PR DESCRIPTION
Hey! In this moment, the retry count for 429 response is set to 2. In some cases, that value doesn't help, since in between retries there are other requests made to the same domain.

I've added an option so users can configure that count. By default, it is set to 2.
Cheers!