### PR TITLE
fixes 429 "Too Many Requests" retries that don't follow standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Parameters:
    * `headers` a string based attribute value object to send custom HTTP headers. Example: `{ 'Authorization' : 'Basic Zm9vOmJhcg==' }`.
    * `retryOn429` a boolean indicating whether to retry on a 429 (Too Many Requests) response. When true, a retry will only be attempted when the response includes a `retry-after` header that indicates how long to wait before retrying.
    * `retryCount` the number of retries to be made on a 429 response. Default `2`.
+   * `fallbackRetryDelay` the delay in [zeit/ms](https://www.npmjs.com/package/ms) format. (e.g. `"2000ms"`, `20s`, `1m`) for retries on a 429 response when no retry-after header is returned. Default is `60s`.
  * `callback` function which accepts `(err, result)`.
    * `err` an Error object when the operation cannot be completed, otherwise `null`.
    * `result` an object with the following properties:

--- a/index.js
+++ b/index.js
@@ -16,10 +16,6 @@ module.exports = function linkCheck(link, opts, callback) {
         opts = {};
     }
 
-    opts.timeout = opts.timeout || '10s';
-    opts.retryOn429 = opts.retryOn429 || false;
-    opts.retryCount = opts.retryCount || 2;
-
     const protocol = (url.parse(link, false, true).protocol || url.parse(opts.baseUrl, false, true).protocol || 'unknown:').replace(/:$/, '');
     if (!protocols.hasOwnProperty(protocol)) {
         callback(new Error('Unsupported Protocol'), null);

--- a/lib/proto/http.js
+++ b/lib/proto/http.js
@@ -8,11 +8,12 @@ const request = require('request');
 
 module.exports = {
 
-    check: function check(link, opts, callback, attempts) {
+    check: function check(link, opts, callback, attempts, additionalMessage) {
 
         if (attempts == null) {
             attempts = 0;
         }
+
         const options = {
             uri: link,
             headers: {
@@ -23,7 +24,7 @@ module.exports = {
             strictSSL: false,
             timeout: ms(opts.timeout),
         };
-        
+
         if (opts.baseUrl && isRelativeUrl(link)) {
             options.baseUrl = opts.baseUrl;
         }
@@ -34,38 +35,64 @@ module.exports = {
 
         request.head(options, function (err, res, body) {
             if (!err && res.statusCode === 200) {
+                if (additionalMessage){
+                  err = (err == null) ? additionalMessage : `${err} ${additionalMessage}`;
+                }
                 callback(null, new LinkCheckResult(opts, link, res ? res.statusCode : 0, err)); // alive, returned 200 OK
                 return;
             }
 
             // if HEAD fails (405 Method Not Allowed, etc), try GET
             request.get(options, function (err, res) {
+              debugger
                 // If enabled in opts, the response was a 429 (Too Many Requests) and there is a retry-after provided, wait and then retry
                 if (opts.retryOn429 && res && res.statusCode === 429 && res.headers.hasOwnProperty('retry-after') && attempts < 2) {
                     const retryStr = res.headers['retry-after'];
-                    // Sites may respond with a retry-after such as '1m30s', so we need to split this into distinct
-                    // time units (separate '1m' and '30s') for zeit/ms to parse them
                     let retryInMs = 0;
-                    let buf = '';
-                    let letter = false;
-                    for (let i = 0; i < retryStr.length; i++) {
-                        let c = retryStr[i];
-                        if (isNaN(c)) {
-                            letter = true;
-                            buf += c;
-                        } else {
-                            if (letter) {
-                                retryInMs += ms(buf.trim());
-                                buf = '';
-                            }
-                            letter = false;
-                            buf += c;
-                        }
+                    // Standard for 'retry-after' header is in seconds.
+                    // the format have to be checked before to see if it's an integer or a complex one.
+                    // see https://github.com/tcort/link-check/issues/24
+
+                    if(isNaN(retryStr)){
+                      // Some HTTP servers return a non standard 'retry-after' header with incorrect values according to <https://tools.ietf.org/html/rfc7231#section-7.1.3>.
+                      // tcort/link-check implemented a retry system to mainly enable Github links to be tested.
+                      // Hopefully Github fixed this non standard behaviour on their side.
+                      // tcort/link-check will then stop the support of non standard 'retry-after' header for releases greater or equal to 4.7.0.
+                      // all this 'isNaN' part and the additionalMessage will then be removed from the code.
+                      additionalMessage =
+                        "Server returned a non standard \'retry-after\' header. "
+                        + "Non standard \'retry-after\' header will not work after link-check 4.7.0 release. "
+                        + "See https://github.com/tcort/link-check/releases/tag/v4.5.2 release note for details.";
+
+                      let buf = '';
+                      let letter = false;
+                      for (let i = 0; i < retryStr.length; i++) {
+                          let c = retryStr[i];
+                          if (isNaN(c)) {
+                              letter = true;
+                              buf += c;
+                          } else {
+                              if (letter) {
+                                  retryInMs += ms(buf.trim());
+                                  buf = '';
+                              }
+                              letter = false;
+                              buf += c;
+                          }
+                      }
+                      retryInMs += ms(buf.trim());
+                    }else{
+                      // standard compliant header value conversion to milliseconds
+                      const secondsToMilisecondsMultiplier = 1000;
+                      retryInMs = parseFloat(retryStr) * secondsToMilisecondsMultiplier;
                     }
-                    retryInMs += ms(buf.trim());
+
                     // Recurse back after the retry timeout has elapsed (incrementing our attempts to avoid an infinite loop)
-                    setTimeout(check, retryInMs, link, opts, callback, attempts + 1);
+                    setTimeout(check, retryInMs, link, opts, callback, attempts + 1, additionalMessage);
                 } else {
+                    if (additionalMessage){
+                      err = (err == null) ? additionalMessage : `${err} ${additionalMessage}`;
+                    }
                     callback(null, new LinkCheckResult(opts, link, res ? res.statusCode : 0, err));
                 }
             }).pipe(new BlackHole());

--- a/lib/proto/http.js
+++ b/lib/proto/http.js
@@ -46,7 +46,6 @@ module.exports = {
 
             // if HEAD fails (405 Method Not Allowed, etc), try GET
             request.get(options, function (err, res) {
-              debugger
                 // If enabled in opts, the response was a 429 (Too Many Requests) and there is a retry-after provided, wait and then retry
                 if (opts.retryOn429 && res && res.statusCode === 429 && res.headers.hasOwnProperty('retry-after') && attempts < opts.retryCount) {
                     const retryStr = res.headers['retry-after'];

--- a/lib/proto/http.js
+++ b/lib/proto/http.js
@@ -33,7 +33,11 @@ module.exports = {
             Object.assign(options.headers, opts.headers);
         }
 
+        //max retry count will default to 2 seconds if no config is found
         let retryCount = opts.retryCount || 2;
+
+        //fallback retry delay will default to 60 seconds if no config is found
+        let fallbackRetryDelayInMs = ms(opts.fallbackRetryDelay || '60s');
 
         request.head(options, function (err, res, body) {
             if (!err && res.statusCode === 200) {
@@ -47,47 +51,49 @@ module.exports = {
             // if HEAD fails (405 Method Not Allowed, etc), try GET
             request.get(options, function (err, res) {
                 // If enabled in opts, the response was a 429 (Too Many Requests) and there is a retry-after provided, wait and then retry
-                if (opts.retryOn429 && res && res.statusCode === 429 && res.headers.hasOwnProperty('retry-after') && attempts < opts.retryCount) {
-                    const retryStr = res.headers['retry-after'];
-                    let retryInMs = 0;
-                    // Standard for 'retry-after' header is in seconds.
-                    // the format have to be checked before to see if it's an integer or a complex one.
-                    // see https://github.com/tcort/link-check/issues/24
+                if (opts.retryOn429 && res && res.statusCode === 429 && attempts < opts.retryCount) {
+                    //delay will default to fallbackRetryDelay if no retry-after header is found
+                    let retryInMs = fallbackRetryDelayInMs;
+                    if (res.headers.hasOwnProperty('retry-after')){
+                        const retryStr = res.headers['retry-after'];
+                        // Standard for 'retry-after' header is in seconds.
+                        // the format have to be checked before to see if it's an integer or a complex one.
+                        // see https://github.com/tcort/link-check/issues/24
 
-                    if(isNaN(retryStr)){
-                      // Some HTTP servers return a non standard 'retry-after' header with incorrect values according to <https://tools.ietf.org/html/rfc7231#section-7.1.3>.
-                      // tcort/link-check implemented a retry system to mainly enable Github links to be tested.
-                      // Hopefully Github fixed this non standard behaviour on their side.
-                      // tcort/link-check will then stop the support of non standard 'retry-after' header for releases greater or equal to 4.7.0.
-                      // all this 'isNaN' part and the additionalMessage will then be removed from the code.
-                      additionalMessage =
-                        "Server returned a non standard \'retry-after\' header. "
-                        + "Non standard \'retry-after\' header will not work after link-check 4.7.0 release. "
-                        + "See https://github.com/tcort/link-check/releases/tag/v4.5.2 release note for details.";
+                        if(isNaN(retryStr)){
+                          // Some HTTP servers return a non standard 'retry-after' header with incorrect values according to <https://tools.ietf.org/html/rfc7231#section-7.1.3>.
+                          // tcort/link-check implemented a retry system to mainly enable Github links to be tested.
+                          // Hopefully Github fixed this non standard behaviour on their side.
+                          // tcort/link-check will then stop the support of non standard 'retry-after' header for releases greater or equal to 4.7.0.
+                          // all this 'isNaN' part and the additionalMessage will then be removed from the code.
+                          additionalMessage =
+                            "Server returned a non standard \'retry-after\' header. "
+                            + "Non standard \'retry-after\' header will not work after link-check 4.7.0 release. "
+                            + "See https://github.com/tcort/link-check/releases/tag/v4.5.2 release note for details.";
 
-                      let buf = '';
-                      let letter = false;
-                      for (let i = 0; i < retryStr.length; i++) {
-                          let c = retryStr[i];
-                          if (isNaN(c)) {
-                              letter = true;
-                              buf += c;
-                          } else {
-                              if (letter) {
-                                  retryInMs += ms(buf.trim());
-                                  buf = '';
+                          let buf = '';
+                          let letter = false;
+                          for (let i = 0; i < retryStr.length; i++) {
+                              let c = retryStr[i];
+                              if (isNaN(c)) {
+                                  letter = true;
+                                  buf += c;
+                              } else {
+                                  if (letter) {
+                                      retryInMs += ms(buf.trim());
+                                      buf = '';
+                                  }
+                                  letter = false;
+                                  buf += c;
                               }
-                              letter = false;
-                              buf += c;
                           }
-                      }
-                      retryInMs += ms(buf.trim());
-                    }else{
-                      // standard compliant header value conversion to milliseconds
-                      const secondsToMilisecondsMultiplier = 1000;
-                      retryInMs = parseFloat(retryStr) * secondsToMilisecondsMultiplier;
+                          retryInMs = ms(buf.trim());
+                        }else{
+                          // standard compliant header value conversion to milliseconds
+                          const secondsToMilisecondsMultiplier = 1000;
+                          retryInMs = parseFloat(retryStr) * secondsToMilisecondsMultiplier;
+                        }
                     }
-
                     // Recurse back after the retry timeout has elapsed (incrementing our attempts to avoid an infinite loop)
                     setTimeout(check, retryInMs, link, opts, callback, attempts + 1, additionalMessage);
                 } else {

--- a/lib/proto/http.js
+++ b/lib/proto/http.js
@@ -14,6 +14,18 @@ module.exports = {
             attempts = 0;
         }
 
+        // default request timeout set to 10s if not provided in options
+        let timeout = opts.timeout || '10s';
+
+        // retry on 429 http code flag is false by default if not provided in options
+        let retryOn429 = opts.retryOn429 || false;
+
+        //max retry count will default to 2 seconds if not provided in options
+        let retryCount = opts.retryCount || 2;
+
+        //fallback retry delay will default to 60 seconds not provided in options
+        let fallbackRetryDelayInMs = ms(opts.fallbackRetryDelay || '60s');
+
         const options = {
             uri: link,
             headers: {
@@ -22,7 +34,7 @@ module.exports = {
             },
             maxRedirects: 8,
             strictSSL: false,
-            timeout: ms(opts.timeout),
+            timeout: ms(timeout),
         };
 
         if (opts.baseUrl && isRelativeUrl(link)) {
@@ -32,12 +44,6 @@ module.exports = {
         if (opts.headers) {
             Object.assign(options.headers, opts.headers);
         }
-
-        //max retry count will default to 2 seconds if no config is found
-        let retryCount = opts.retryCount || 2;
-
-        //fallback retry delay will default to 60 seconds if no config is found
-        let fallbackRetryDelayInMs = ms(opts.fallbackRetryDelay || '60s');
 
         request.head(options, function (err, res, body) {
             if (!err && res.statusCode === 200) {
@@ -51,7 +57,7 @@ module.exports = {
             // if HEAD fails (405 Method Not Allowed, etc), try GET
             request.get(options, function (err, res) {
                 // If enabled in opts, the response was a 429 (Too Many Requests) and there is a retry-after provided, wait and then retry
-                if (opts.retryOn429 && res && res.statusCode === 429 && attempts < opts.retryCount) {
+                if (retryOn429 && res && res.statusCode === 429 && attempts < retryCount) {
                     //delay will default to fallbackRetryDelay if no retry-after header is found
                     let retryInMs = fallbackRetryDelayInMs;
                     if (res.headers.hasOwnProperty('retry-after')){

--- a/test/link-check.test.js
+++ b/test/link-check.test.js
@@ -422,24 +422,23 @@ describe('link-check', function () {
         });
     });
 
-    it('should retry after 1s delay on HTTP 429 without header', function (done) {
-        linkCheck(baseUrl + '/later-no-header', { retryOn429: true, fallbackRetryDelay: '1s' },  function (err, result) {
-            expect(err).to.be(null);
-            expect(result.err).to.be(null);
-            expect(result.link).to.be(baseUrl + '/later-no-header');
-            expect(result.status).to.be('alive');
-            expect(result.statusCode).to.be(200);
-            done();
-        });
-    });
-
-
     it('should retry after the provided delay on HTTP 429 with non standard header, and return a warning', function (done) {
         linkCheck(baseUrl + '/later-non-standard-header', { retryOn429: true },  function (err, result) {
             expect(err).to.be(null);
             expect(result.err).not.to.be(null)
             expect(result.err).to.contain("Server returned a non standard \'retry-after\' header.");
             expect(result.link).to.be(baseUrl + '/later-non-standard-header');
+            expect(result.status).to.be('alive');
+            expect(result.statusCode).to.be(200);
+            done();
+        });
+    });
+
+    it('should retry after 1s delay on HTTP 429 without header', function (done) {
+        linkCheck(baseUrl + '/later-no-header', { retryOn429: true, fallbackRetryDelay: '1s' },  function (err, result) {
+            expect(err).to.be(null);
+            expect(result.err).to.be(null);
+            expect(result.link).to.be(baseUrl + '/later-no-header');
             expect(result.status).to.be('alive');
             expect(result.statusCode).to.be(200);
             done();


### PR DESCRIPTION
Some HTTP servers return a non standard 'retry-after' header with incorrect values according to <https://tools.ietf.org/html/rfc7231#section-7.1.3> and <https://tools.ietf.org/html/rfc6585#section-4>

This PR provides:

- standard compliant retry delay duration handling
- error message provided to inform user in case of non standard server response (non breaking as it still returns the success code if the link is finally reached with a code 200)
- provide tests for the 429 "Too Many Requests" retries case
- merged with changes from #22 and fixed issues that it brought to my changes
  - Added a default value to 2 for retries in the http and not only on the CLI
  - removed a redundant test case
  - updated custom retry test to match others
- add a default retry delay in case of no retry-after header is present in the server response (see [rfc6585](https://tools.ietf.org/html/rfc6585#section-4)). The default is 60s but can be overridden by config.
- move config defaults to the relevant place (http protocol only)

The suggested error message in this PR is to deprecate non standard response starting from link-check 4.5.2 (next release) and totally remove it for 4.7.0.

fixes #24