### PR TITLE
Encode urls to prevent unicode chars to fail

### DIFF
--- a/lib/proto/http.js
+++ b/lib/proto/http.js
@@ -27,7 +27,7 @@ module.exports = {
         let fallbackRetryDelayInMs = ms(opts.fallbackRetryDelay || '60s');
 
         const options = {
-            uri: link,
+            uri: encodeURI(link),
             headers: {
                 // override 'User-Agent' (some sites return `401` when the user-agent isn't a web browser)
                 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36'

--- a/test/link-check.test.js
+++ b/test/link-check.test.js
@@ -120,6 +120,10 @@ describe('link-check', function () {
             }
         });
 
+        app.get(encodeURI('/url_with_unicode–'), function (req, res) {
+            res.sendStatus(200);
+        });
+
         const server = http.createServer(app);
         server.listen(0 /* random open port */, 'localhost', function serverListen(err) {
             if (err) {
@@ -449,6 +453,17 @@ describe('link-check', function () {
     it('should retry 3 times for 429 status codes', function(done) {
         laterCustomRetryCounter = 0;
         linkCheck(baseUrl + '/later-custom-retry-count?successNumber=3', { retryOn429: true, retryCount: 3 }, function(err, result) {
+            expect(err).to.be(null);
+            expect(result.err).to.be(null);
+            expect(result.status).to.be('alive');
+            expect(result.statusCode).to.be(200);
+            done();
+        });
+    });
+
+    it('should handle unicode chars in URLs', function(done) {
+        laterCustomRetryCounter = 0;
+        linkCheck(baseUrl + '/url_with_unicode–', function(err, result) {
             expect(err).to.be(null);
             expect(result.err).to.be(null);
             expect(result.status).to.be('alive');


### PR DESCRIPTION
fixes #23 

Note: this doesn't include updating to a non deprecated http client
to move away from request. This will be done in another PR.
It seems that no client handles unicode anyway. I tested some before
simply take the encoding option. Seeing visual unicode chars seems to
be a browser feature not in the spec. Node http for instance only
handles latin and latin1 ranges (0021 to 00ff).