### PR TITLE
Use decodeURIComponent() instead of decodeURI()

### DIFF
--- a/lib/proto/http.js
+++ b/lib/proto/http.js
@@ -28,7 +28,12 @@ module.exports = {
 
         const options = {
             // Decoding and encoding is required to prevent encoding already encoded URLs
-            uri: encodeURI(decodeURI(link)),
+            // We decode using the decodeURIComponent as it will decode a wider range of
+            // characters that were not necessary to be encoded at first, then we re-encode
+            // only the required ones using encodeURI.
+            // Note that we don't use encodeURIComponents as it adds too much non-necessary encodings
+            // see "Not Escaped" list in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#description
+            uri: encodeURI(decodeURIComponent(link)),
             headers: {
                 // override 'User-Agent' (some sites return `401` when the user-agent isn't a web browser)
                 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36'

--- a/test/link-check.test.js
+++ b/test/link-check.test.js
@@ -124,7 +124,7 @@ describe('link-check', function () {
             res.sendStatus(200);
         });
 
-        app.get('/url_\\(with_parentheses\\)', function (req, res) {
+        app.get('/url_with_special_chars\\(\\)\\+', function (req, res) {
             res.sendStatus(200);
         });
 
@@ -465,8 +465,9 @@ describe('link-check', function () {
         });
     });
 
-    it('should handle unicode chars in URLs', function(done) {
-        laterCustomRetryCounter = 0;
+    // See issue #23
+    it('should handle non URL encoded unicode chars in URLs', function(done) {
+        //last char is 	EN DASH
         linkCheck(baseUrl + '/url_with_unicode–', function(err, result) {
             expect(err).to.be(null);
             expect(result.err).to.be(null);
@@ -476,10 +477,9 @@ describe('link-check', function () {
         });
     });
 
-    it('should not encode already encoded characters', function(done) {
-        laterCustomRetryCounter = 0;
-        linkCheck(baseUrl + '/url_%28with_parentheses%29', function(err, result) {
-          console.log(err, result);
+    // See issues #34 and #40
+    it('should not URL encode already encoded characters', function(done) {
+        linkCheck(baseUrl + '/url_with_special_chars%28%29%2B', function(err, result) {
             expect(err).to.be(null);
             expect(result.err).to.be(null);
             expect(result.status).to.be('alive');


### PR DESCRIPTION
- decode using the decodeURIComponent as it will decode a wider range of characters that were not necessary to be encoded at first, then re-encode only the required ones using encodeURI.
- add the new test case and some comments on tests to identifie the related issues

fixes #40