### PR TITLE
docs: Format with Markdownlint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,10 @@ Changes:
 
 This release contains the following potentially breaking changes:
 
-- bad/expired/unauthorized HTTPS certificate errors are no longer ignored.
- - sites with bad certs are no longer considered `alive`
-- `User-Agent` header no longer impersonates Firefox.
- - defaults to `link-check/5.0.0` (override via `opts.user_agent`).
+* bad/expired/unauthorized HTTPS certificate errors are no longer ignored.
+  * sites with bad certs are no longer considered `alive`
+* `User-Agent` header no longer impersonates Firefox.
+  * defaults to `link-check/5.0.0` (override via `opts.user_agent`).
 
 Changes:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Checks whether a hyperlink is alive (`200 OK`) or dead.
 
 ## Installation
 
-    npm install --save link-check
+```console
+npm install --save link-check
+```
 
 ## Specification
 
@@ -26,24 +28,24 @@ Given a `link` and a `callback`, attempt an HTTP HEAD and possibly an HTTP GET.
 
 Parameters:
 
- * `url` string containing a URL.
- * `opts` optional options object containing any of the following optional fields:
-   * `anchors` array of anchor strings (e.g. `[ "#foo", "#bar" ]`) for checking anchor links (e.g. `<a href="#foo">Foo</a>`).
-   * `baseUrl` the base URL for relative links.
-   * `timeout` timeout in [zeit/ms](https://www.npmjs.com/package/ms) format. (e.g. `"2000ms"`, `20s`, `1m`). Default `10s`.
-   * `user_agent` the user-agent string. Default `${name}/${version}` (e.g. `link-check/4.5.5`)
-   * `aliveStatusCodes` an array of numeric HTTP Response codes which indicate that the link is alive. Entries in this array may also be regular expressions. Example: `[ 200, /^[45][0-9]{2}$/ ]`.  Default `[ 200 ]`.
-   * `headers` a string based attribute value object to send custom HTTP headers. Example: `{ 'Authorization' : 'Basic Zm9vOmJhcg==' }`.
-   * `retryOn429` a boolean indicating whether to retry on a 429 (Too Many Requests) response. When true, if the response has a 429 HTTP code and includes an optional `retry-after` header, a retry will be attempted after the delay indicated in the `retry-after` header. If no `retry-after` header is present in the response or the `retry-after` header value is not valid according to [RFC7231](https://tools.ietf.org/html/rfc7231#section-7.1.3) (value must be in seconds), a default retry delay of 60 seconds will apply. This default can be overriden by the `fallbackRetryDelay` parameter.
-   * `retryCount` the number of retries to be made on a 429 response. Default `2`.
-   * `fallbackRetryDelay` the delay in [zeit/ms](https://www.npmjs.com/package/ms) format. (e.g. `"2000ms"`, `20s`, `1m`) for retries on a 429 response when no `retry-after` header is returned or when it has an invalid value. Default is `60s`.
- * `callback` function which accepts `(err, result)`.
-   * `err` an Error object when the operation cannot be completed, otherwise `null`.
-   * `result` an object with the following properties:
-     * `link` the `link` provided as input
-     * `status` a string set to either `alive` or `dead`.
-     * `statusCode` the HTTP status code. Set to `0` if no HTTP status code was returned (e.g. when the server is down).
-     * `err` any connection error that occurred, otherwise `null`.
+* `url` string containing a URL.
+* `opts` optional options object containing any of the following optional fields:
+  * `anchors` array of anchor strings (e.g. `[ "#foo", "#bar" ]`) for checking anchor links (e.g. `<a href="#foo">Foo</a>`).
+  * `baseUrl` the base URL for relative links.
+  * `timeout` timeout in [zeit/ms](https://www.npmjs.com/package/ms) format. (e.g. `"2000ms"`, `20s`, `1m`). Default `10s`.
+  * `user_agent` the user-agent string. Default `${name}/${version}` (e.g. `link-check/4.5.5`)
+  * `aliveStatusCodes` an array of numeric HTTP Response codes which indicate that the link is alive. Entries in this array may also be regular expressions. Example: `[ 200, /^[45][0-9]{2}$/ ]`.  Default `[ 200 ]`.
+  * `headers` a string based attribute value object to send custom HTTP headers. Example: `{ 'Authorization' : 'Basic Zm9vOmJhcg==' }`.
+  * `retryOn429` a boolean indicating whether to retry on a 429 (Too Many Requests) response. When true, if the response has a 429 HTTP code and includes an optional `retry-after` header, a retry will be attempted after the delay indicated in the `retry-after` header. If no `retry-after` header is present in the response or the `retry-after` header value is not valid according to [RFC7231](https://tools.ietf.org/html/rfc7231#section-7.1.3) (value must be in seconds), a default retry delay of 60 seconds will apply. This default can be overriden by the `fallbackRetryDelay` parameter.
+  * `retryCount` the number of retries to be made on a 429 response. Default `2`.
+  * `fallbackRetryDelay` the delay in [zeit/ms](https://www.npmjs.com/package/ms) format. (e.g. `"2000ms"`, `20s`, `1m`) for retries on a 429 response when no `retry-after` header is returned or when it has an invalid value. Default is `60s`.
+* `callback` function which accepts `(err, result)`.
+  * `err` an Error object when the operation cannot be completed, otherwise `null`.
+  * `result` an object with the following properties:
+    * `link` the `link` provided as input
+    * `status` a string set to either `alive` or `dead`.
+    * `statusCode` the HTTP status code. Set to `0` if no HTTP status code was returned (e.g. when the server is down).
+    * `err` any connection error that occurred, otherwise `null`.
 
 ## Examples
 
@@ -79,7 +81,9 @@ linkCheck('http://example.com', { headers: { 'Authorization': 'Basic Zm9vOmJhcg=
 
 ## Testing
 
-    npm test
+```console
+npm test
+```
 
 ## License
 


### PR DESCRIPTION
Just ran on the root files to cleanup some minor formatting. Didn't touch any of the fixtures

Few others I didn't look at
```
$ markdownlint-cli2-fix "*.md"
markdownlint-cli2-fix v0.6.0 (markdownlint v0.27.0)
Finding: *.md
Linting: 4 file(s)
Summary: 10 error(s)
LICENSE.md:1 MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading [Context: "Copyright (c) 2016-2021 Thomas..."]
README.md:1 MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading [Context: "![Test library workflow status..."]
README.md:33:81 MD013/line-length Line length [Expected: 80; Actual: 124]
README.md:35:81 MD013/line-length Line length [Expected: 80; Actual: 123]
README.md:37:81 MD013/line-length Line length [Expected: 80; Actual: 214]
README.md:38:81 MD013/line-length Line length [Expected: 80; Actual: 135]
README.md:39:81 MD013/line-length Line length [Expected: 80; Actual: 588]
README.md:41:81 MD013/line-length Line length [Expected: 80; Actual: 242]
README.md:47:81 MD013/line-length Line length [Expected: 80; Actual: 119]
README.md:73:81 MD013/line-length Line length [Expected: 80; Actual: 112]
```