### PR TITLE
fix failing github action with IPv6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - 20
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,15 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 14
-          - 16
           - 18
           - 19
+          - 20
 
     steps:
     - uses: actions/checkout@v3
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: npm

--- a/test/link-check.test.js
+++ b/test/link-check.test.js
@@ -134,7 +134,13 @@ describe('link-check', function () {
                 done(err);
                 return;
             }
-            baseUrl = 'http://' + server.address().address + ':' + server.address().port;
+            // github action uses IPv6 addresses
+            // there seems missing IPv6 support in upstream libs
+            if (server.address().address === "::1") {
+                baseUrl = 'http://localhost:' + server.address().port;
+            } else {
+                baseUrl = 'http://' + server.address().address + ':' + server.address().port;
+            }
             done();
         });
     });


### PR DESCRIPTION
Node 14 and 16 are EoL.

Since Node 18 github action uses IPv6 (host: `::1`). This should in url: `[::1]`.
But any lib seems to be incompatible.