### PR TITLE
Defer protocol imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,11 @@
 const { URL } = require('url');
 
 const protocols = {
-    hash: require('./lib/proto/hash'),
-    file: require('./lib/proto/file'),
-    http: require('./lib/proto/http'),
-    https: require('./lib/proto/https'),
-    mailto: require('./lib/proto/mailto'),
+    hash: function () { return require('./lib/proto/hash'); },
+    file: function () { return require('./lib/proto/file'); },
+    http: function () { return require('./lib/proto/http'); },
+    https: function () { return require('./lib/proto/https'); },
+    mailto: function () { return require('./lib/proto/mailto'); },
 };
 
 module.exports = function linkCheck(link, opts, callback) {
@@ -26,7 +26,7 @@ module.exports = function linkCheck(link, opts, callback) {
         return;
     }
 
-    protocols[protocol].check(link, opts, callback);
+    protocols[protocol]().check(link, opts, callback);
 };
 
 module.exports.LinkCheckResult = require('./lib/LinkCheckResult');


### PR DESCRIPTION
This PR brings a massive performance improvement when importing link-check. These are the results on my linux machine:

Before:

```sh
$ time for i in {1..30}; do node -e 'require("./index.js")'; done

real   0m5,393s
user   0m5,424s
sys    0m1,395s
```

After:

```sh
$ time for i in {1..30}; do node -e 'require("./index.js")'; done

real   0m1,678s
user   0m1,032s
sys    0m0,670s
```