### PR TITLE
Decrease package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "5.3.0",
   "description": "checks whether a hyperlink is alive (200 OK) or dead",
   "main": "index.js",
+  "files": [
+    "CHANGELOG.md",
+    "LICENSE.md",
+    "README.md",
+    "lib"
+  ],
   "scripts": {
     "pretest": "jshint index.js lib test",
     "test": "mocha -R spec --exit"


### PR DESCRIPTION
Only include in the final package the files that are really used. This can be checked executing `npm pack` locally.

Before:

```
npm notice package size:  9.6 kB                                  
npm notice unpacked size: 38.0 kB
```

After:

```
npm notice package size:  6.5 kB                                  
npm notice unpacked size: 17.7 kB
```