### PR TITLE
ci: use current node.js versions in matrix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,9 @@ jobs:
       matrix:
         node-version:
           - 18
-          - 19
           - 20
+          - 22
+          - 23
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Issue

The Node.js versions used in the matrix of [.github/workflows/ci.yml](https://github.com/tcort/link-check/blob/master/.github/workflows/ci.yml) are no longer aligned with versions of Node.js shown as active under the [Node.js release schedule](https://github.com/nodejs/release#release-schedule):

| Node.js version | Status                  |
| --------------- | ----------------------- |
| 19.x            | End-of-life Jun 1, 2023 |
| 22.x            | Released Apr 24, 2024   |
| 23.x            | Released Oct 15, 2024   |

## Change

In [.github/workflows/ci.yml](https://github.com/tcort/link-check/blob/master/.github/workflows/ci.yml) make the following changes to the `node-version` matrix:

| Node.js version | Change |
| --------------- | ------ |
| 19              | Drop   |
| 22              | Add    |
| 23              | Add    |
